### PR TITLE
change to at indexing to prevent out of range access

### DIFF
--- a/src/CppOutputParser.hpp
+++ b/src/CppOutputParser.hpp
@@ -2,6 +2,7 @@
 #define SISC_LAB_CPPOUTPUTPARSER_HPP
 
 #include <iostream>
+#include <cassert>
 #include "OutputParser.hpp"
 #include "absl/strings/str_cat.h"
 
@@ -16,26 +17,26 @@ void CppOutputParser::parse(std::pair<std::vector<std::string>, std::vector<int>
     assert(input.first.size() == input.second.size());
 
     // loop over all input first but compare to the integer which is in input second
-    for (size_t i = 0; i < input.first.size(); ++i) {
+    for (size_t i = 0; i < input.first.size()-1; ++i) {
         // indentation based on the indentaion level integer counter
-        auto indentation = std::string(input.second[i],'\t');
+        auto indentation = std::string(input.second.at(i),'\t');
 
         // adding brackets if the levels do change
-        if (input.second[i+1] > input.second[i]) {
+        if (input.second.at(i+1) > input.second.at(i)) {
             // add opening bracket if next indentation is bigger
-            input.first[i] = absl::StrCat(indentation, input.first[i], "{");
-        } else if (input.second[i+1] < input.second[i]) {
+            input.first.at(i) = absl::StrCat(indentation, input.first.at(i), "{");
+        } else if (input.second.at(i+1) < input.second.at(i)) {
             // add closing bracket if next indentation is smaller
-            input.first[i] = absl::StrCat(indentation, input.first[i], ";}");
+            input.first.at(i) = absl::StrCat(indentation, input.first.at(i), ";}");
         } else {
             // add simple semicolon at end of a line
-            input.first[i] = absl::StrCat(indentation, input.first[i], ";");
+            input.first.at(i) = absl::StrCat(indentation, input.first.at(i), ";");
         }
-
-        if (i == input.first.size()-1 && input.second[i] != 1) {
+        if ((i+1) == input.first.size()-1 && input.second.at(i+1) != 0) {
             // add as many needed closing brackets at the end as needed
-            auto closing_brackets = std::string(input.second[i]-1,'}');
-            input.first[i] = absl::StrCat(input.first[i], closing_brackets);
+            indentation = std::string(input.second.at(i+1),'\t');
+            auto closing_brackets = std::string(input.second.at(i+1),'}');
+            input.first.at(i+1) = absl::StrCat(indentation,input.first.at(i+1), ";", closing_brackets);
         }
     }
 }


### PR DESCRIPTION
Could one on Windows please verify if it is fixed with this commit?

I guess the problem was mainly due to an indexing at `i+1` which was then outside the vectors. Thus, the value was some rubbish value currently in the ram or so.

With this commit this should be prevented, with the usage of the `at` indexing also checking for out of bound access.